### PR TITLE
(ci) Add GitHub Action for publishing site on pushes to master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish halleluja.nu web site
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.302
+
+    - name: Rebuild sitegen
+      run: make sitegen
+
+    - name: Rebuild site
+      run: make site
+
+    - name: Publish site to web server
+      uses: easingthemes/ssh-deploy@v2.1.1
+      env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          ARGS: "-rltgoDzvO --delete-after"
+          SOURCE: out/
+          REMOTE_HOST: ${{ secrets.SSH_REMOTE_HOST }}
+          REMOTE_USER: ${{ secrets.SSH_REMOTE_USER }}
+          TARGET: ${{ secrets.SSH_REMOTE_TARGET }}

--- a/src/_includes/footer.hbs
+++ b/src/_includes/footer.hbs
@@ -2,7 +2,7 @@
     <div class="wrapper">
       <div class="footer-col-wrapper">
         <div class="footer-col footer-col-1">
-          &copy; {{ now.year }} {{ site.title }}
+          &copy; 2002-{{ now.year }} {{ site.title }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This completes the Finished Work of making https://www.halleluja.nu be:

- built using [sitegen](https://github.com/perlun/sitegen)
- including existing blog posts
- fully automatically deployed, on each push to master :tada: 